### PR TITLE
Reusable ts workflow

### DIFF
--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -1,0 +1,62 @@
+name: Typescript Features Testing
+on:
+  workflow_call:
+    inputs:
+      typescript-repo-ref:
+        required: true
+        type: string
+        default: 'main'
+
+jobs:
+  build-ts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./sdk-ts
+    steps:
+      - name: Print git info
+        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, ts repo ref: ${{ inputs.typescript-repo-ref }}'
+        working-directory: '.'
+
+      - name: Checkout SDK features repo
+        uses: actions/checkout@v2
+        with:
+          # Weirdly, this must be specified otherwise if the workflow is re-used from an sdk repo
+          # this will just check out the SDK repo.
+          repository: temporalio/sdk-features
+          path: sdk-features
+      - name: Checkout typescript SDK repo
+        uses: actions/checkout@v2
+        with:
+          repository: temporalio/sdk-typescript
+          submodules: recursive
+          path: sdk-ts
+          ref: ${{ inputs.typescript-repo-ref }}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17'
+
+
+      # Don't build during install phase since we're going to explicitly build
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+        env:
+          BUILD_CORE_RELEASE: true
+      - name: Build sdk-features go
+        run: go build
+        working-directory: ./sdk-features
+
+      - name: Get Temporal docker-compose.yml
+        run: wget https://raw.githubusercontent.com/temporalio/docker-compose/v1.13.0/docker-compose.yml
+      - name: Start Temporal Server
+        run: docker-compose up -d
+      - name: Wait for Temporal Server
+        run: npm run wait-namespace
+
+      - name: Run SDK-features tests
+        run: go run . run --lang ts --server localhost:7233 --namespace default --version "$(realpath ../sdk-ts)"
+        working-directory: ./sdk-features

--- a/harness/ts/harness.ts
+++ b/harness/ts/harness.ts
@@ -55,7 +55,7 @@ export class FeatureSource {
     const dirents = await fs.readdir(absDir, { withFileTypes: true });
     const dirs = [];
     for (const dirent of dirents) {
-      if (dirent.name === 'feature.ts') {
+      if (dirent.name === 'feature.js') {
         const relDir = path.relative(origRootDir, absDir).replaceAll(path.sep, '/');
         dirs.push(new FeatureSource(relDir, absDir));
       } else if (dirent.isDirectory()) {
@@ -73,7 +73,7 @@ export class FeatureSource {
 
   loadFeature<W extends Workflow, A extends ActivityInterface>(): Feature<W, A> {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(path.join(this.absDir, 'feature.ts')).feature;
+    return require(path.join(this.absDir, 'feature.js')).feature;
   }
 }
 
@@ -100,7 +100,7 @@ export class Runner<W extends Workflow, A extends ActivityInterface> {
 
     // Create and start the worker
     const workflowsPath =
-      feature.options.workflowsPath ?? require.resolve(path.join(source.absDir, 'feature.workflow.ts'));
+      feature.options.workflowsPath ?? require.resolve(path.join(source.absDir, 'feature.workflow.js'));
     const workerOpts: WorkerOptions = {
       workflowsPath,
       activities: feature.activities,
@@ -109,8 +109,6 @@ export class Runner<W extends Workflow, A extends ActivityInterface> {
     if (options.nodeModulesPath) {
       const ourNodeMods = path.join(process.cwd(), 'node_modules');
       workerOpts.nodeModulesPaths = [options.nodeModulesPath, ourNodeMods];
-      // TODO: Remove this `as any` once published version has this addition
-      (workerOpts as any).typescriptContextPath = process.cwd();
     }
     const worker = await Worker.create(workerOpts);
     const workerRunPromise = worker.run().finally(() => conn.client.close());

--- a/harness/ts/package.json.tmpl
+++ b/harness/ts/package.json.tmpl
@@ -2,7 +2,8 @@
   "name": "sdk-features",
   "private": true,
   "scripts": {
-    "start": "ts-node -P ./tsconfig.json -r tsconfig-paths/register {{ .PathToMainTS }}"
+    "build": "tsc -P ./tsconfig.json",
+    "start": "node -r tsconfig-paths/register {{ .PathToMainJS }}"
   },
   "dependencies": {
   {{ if .LocalSDK }}

--- a/harness/ts/tsconfig.json.tmpl
+++ b/harness/ts/tsconfig.json.tmpl
@@ -6,7 +6,7 @@
     "outDir": "./tslib",
     "rootDirs": ["../", "."],
     "paths": {
-      "@temporalio/harness": ["../harness/ts/harness.ts"],
+      "@temporalio/harness": ["./tslib/harness/ts/harness.js", "../harness/ts/harness.ts"],
 
       "*": ["node_modules/*", "node_modules/@types/*"]
     },


### PR DESCRIPTION
Add a reusable GH actions workflow that can be used from within and without this repo to run the TS tests

Also just compile TS instead of doing loader magic