### PR TITLE
Upgrade to latest TS SDK

### DIFF
--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -12,7 +12,7 @@ on:
         default: 'main'
 
 jobs:
-  build-ts:
+  test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -53,13 +53,6 @@ jobs:
         run: go build
         working-directory: ./sdk-features
 
-      - name: Get Temporal docker-compose.yml
-        run: wget https://raw.githubusercontent.com/temporalio/docker-compose/v1.13.0/docker-compose.yml
-      - name: Start Temporal Server
-        run: docker-compose up -d
-      - name: Wait for Temporal Server
-        run: npm run wait-namespace
-
       - name: Run SDK-features tests
-        run: go run . run --lang ts --server localhost:7233 --namespace default --version "$(realpath ../sdk-ts)"
+        run: go run . run --lang ts --version "$(realpath ../sdk-ts)"
         working-directory: ./sdk-features

--- a/cmd/run_typescript.go
+++ b/cmd/run_typescript.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.temporal.io/sdk-features/harness/go/cmd"
-	"go.temporal.io/server/common/log/tag"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"go.temporal.io/sdk-features/harness/go/cmd"
+	"go.temporal.io/server/common/log/tag"
 )
 
 type packageJSONDetails struct {
@@ -111,9 +112,6 @@ func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error 
 	// Run the harness
 	runArgs := []string{"run", "start", "--",
 		"--server", r.config.Server, "--namespace", r.config.Namespace}
-	if localSDK != "" {
-		runArgs = append(runArgs, "--node-modules-path", filepath.Join(localSDK, "node_modules"))
-	}
 	runArgs = append(runArgs, run.ToArgs()...)
 	npmRun := exec.CommandContext(ctx, "npm", runArgs...)
 	npmRun.Dir = tempDir

--- a/harness/ts/harness.ts
+++ b/harness/ts/harness.ts
@@ -1,4 +1,4 @@
-import { Connection, WorkflowClient, WorkflowHandleWithRunId } from '@temporalio/client';
+import { Connection, WorkflowClient, WorkflowHandleWithFirstExecutionRunId } from '@temporalio/client';
 import { ActivityInterface, Workflow, WorkflowResultType } from '@temporalio/common';
 import { Worker, WorkerOptions, NativeConnection } from '@temporalio/worker';
 import { promises as fs } from 'fs';
@@ -27,18 +27,18 @@ export interface FeatureOptions<W extends Workflow, A extends ActivityInterface>
    * Execute the workflow. If unset, defaults to
    * Runner.executeSingleParameterlessWorkflow.
    */
-  execute?: (runner: Runner<W, A>) => Promise<WorkflowHandleWithRunId<W>>;
+  execute?: (runner: Runner<W, A>) => Promise<WorkflowHandleWithFirstExecutionRunId<W>>;
 
   /**
    * Wait on and check the result of the workflow. If unset, defaults to
    * Runner.waitForRunResult.
    */
-  checkResult?: (runner: Runner<W, A>, handle: WorkflowHandleWithRunId<W>) => Promise<void>;
+  checkResult?: (runner: Runner<W, A>, handle: WorkflowHandleWithFirstExecutionRunId<W>) => Promise<void>;
 
   /**
    * Check the history of the workflow run. TODO(cretz): Unhandled currently
    */
-  checkHistory?: (runner: Runner<W, A>, handle: WorkflowHandleWithRunId<W>) => Promise<void>;
+  checkHistory?: (runner: Runner<W, A>, handle: WorkflowHandleWithFirstExecutionRunId<W>) => Promise<void>;
 }
 
 export class Feature<W extends Workflow, A extends ActivityInterface> {
@@ -158,7 +158,7 @@ export class Runner<W extends Workflow, A extends ActivityInterface> {
     }
   }
 
-  async executeSingleParameterlessWorkflow(): Promise<WorkflowHandleWithRunId> {
+  async executeSingleParameterlessWorkflow(): Promise<WorkflowHandleWithFirstExecutionRunId> {
     const workflow = this.feature.options.workflow ?? 'workflow';
     return await this.client.start<() => any>(workflow, {
       taskQueue: this.options.taskQueue,
@@ -166,7 +166,9 @@ export class Runner<W extends Workflow, A extends ActivityInterface> {
     });
   }
 
-  async waitForRunResult<W extends Workflow>(run: WorkflowHandleWithRunId<W>): Promise<WorkflowResultType<W>> {
+  async waitForRunResult<W extends Workflow>(
+    run: WorkflowHandleWithFirstExecutionRunId<W>
+  ): Promise<WorkflowResultType<W>> {
     return await run.result();
   }
 

--- a/harness/ts/main.ts
+++ b/harness/ts/main.ts
@@ -9,11 +9,6 @@ async function run() {
   program
     .requiredOption('--server <address>', 'The host:port of the server')
     .requiredOption('--namespace <namespace>', 'The namespace to use')
-    .option(
-      '--node-modules-path <filepath>',
-      'Overrides node_modules directory that will be used for workflow bundling.' +
-        ' Is needed when using a local version of the TS SDK'
-    )
     .argument('<features...>', 'Features as dir + ":" + task queue');
 
   const opts = program.parse(process.argv).opts<{

--- a/harness/ts/main.ts
+++ b/harness/ts/main.ts
@@ -20,12 +20,8 @@ async function run() {
 
   console.log('Running TypeScript SDK version ' + pkg.version, 'against', opts.server);
 
-  // Install core with our address and namespace
-  const logger = new DefaultLogger('DEBUG');
-  Runtime.install({
-    logger,
-    telemetryOptions: { logForwardingLevel: 'OFF' },
-  });
+  // Set logging to debug
+  Runtime.install({ logger: new DefaultLogger('DEBUG') });
 
   // Collect all feature sources
   const featureRootDir = path.join(__dirname, '../../features');

--- a/harness/ts/package.json.tmpl
+++ b/harness/ts/package.json.tmpl
@@ -25,8 +25,8 @@
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",
     "@types/uuid": "^8.3.4",
+    "source-map-loader": "^3.0.1",
     "ts-node": "^10.4.0",
-    "ts-loader": "^9.2.6",
     "tsconfig-paths": "^3.12.0",
     "typescript": "^4.4.2"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "sdk-features",
       "dependencies": {
         "commander": "^8.3.0",
-        "temporalio": "0.21.1",
+        "temporalio": "1.0.0-rc.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -182,14 +182,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.9.tgz",
-      "integrity": "sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
+        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -218,6 +218,58 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.13.2",
@@ -273,9 +325,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
-      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -283,7 +335,7 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
@@ -298,12 +350,12 @@
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -312,27 +364,27 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@swc/core": {
       "version": "1.2.168",
@@ -560,25 +612,25 @@
       }
     },
     "node_modules/@temporalio/activity": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-0.21.0.tgz",
-      "integrity": "sha512-bGPX2RtjFnSD4q2Z0jQtjRomDY6wLFUjcTpnU1yMePqeG75RyUro7W+4H/82qBEchwX+Nwr1axdjumRBHVm0Rw==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.0.0-rc.0.tgz",
+      "integrity": "sha512-CKApbyvJF/fjPZf5ygEB9pjMtSmbZZ62NcIjtxqvRNAKe6lgrImeIQXK9kyb/CPCZBQCmaKvF+u7pVN9GLWHVw==",
       "dependencies": {
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
         "abort-controller": "^3.0.0"
       }
     },
     "node_modules/@temporalio/client": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-0.21.0.tgz",
-      "integrity": "sha512-x6PIUc9/N7KxtWoa4yIJf3TixrwP3ff87kPg6e5LoWESWNkQis4fWhoLLFEYEYwX9WoPwjb4dmZ3RNGsG1nNqw==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.0.0-rc.0.tgz",
+      "integrity": "sha512-cSlMtUk5rt1jkfarcwn0ECl5pk7VtvcChamKKnNhvVf/K6wtE4b+GG0m6SzUwfIDPJhd/9JXGeXZ2b4i0QgAQg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.7",
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/internal-non-workflow-common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-non-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
         "ms": "^2.1.3",
         "protobufjs": "^6.11.2",
         "uuid": "^8.3.2"
@@ -590,42 +642,43 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@temporalio/common": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-0.21.0.tgz",
-      "integrity": "sha512-VkxTJNOttwmNztucD0FhSntEzxwt1e8pW/x1dfzOkWGP7M5a7EH+gsoImqBlYBRR0ZWwYZPBiqV8UxDfR1pnLA==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.0.0-rc.0.tgz",
+      "integrity": "sha512-jlVoizIJ/ahOLO4L1e1XH+oZXAiMFQ51tNpL2+YNE9Y97ZEzoHYkHeO1e9qBVxxS3iW/4GvQFDSKFVdCO7DB3w==",
       "dependencies": {
-        "@temporalio/internal-workflow-common": "^0.21.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
         "proto3-json-serializer": "^0.1.6"
       }
     },
     "node_modules/@temporalio/core-bridge": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-0.21.1.tgz",
-      "integrity": "sha512-jVJoqEiq1UEP47TJEIt7LekIviaf8fFV+9FVBbS+mX4vD9rqiaergLqy5SUYQnwFH28IaP3hMOLWBSja5GEgsg==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.0.0-rc.0.tgz",
+      "integrity": "sha512-+fm3U6/PhbJwkhnXIE3KCom+A9vzbqVuwayVPrcFB5ZLpx50aj7SJrWi9O6bPTEInrjySKtCTbVLvFBWfsfclw==",
       "hasInstallScript": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.3",
-        "@temporalio/internal-non-workflow-common": "^0.21.0",
+        "@temporalio/internal-non-workflow-common": "^1.0.0-rc.0",
         "arg": "^5.0.1",
         "cargo-cp-artifact": "^0.1.4",
         "which": "^2.0.2"
       }
     },
     "node_modules/@temporalio/internal-non-workflow-common": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/internal-non-workflow-common/-/internal-non-workflow-common-0.21.0.tgz",
-      "integrity": "sha512-Hl7SaS8fZXt/vxvCW+2IttEZSs7Zvi/3IWT4Gp7MvGF9L88CKoWUmN+yj+k8/xWMccM0/9+cMzAyOgjFv7e0ZQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/internal-non-workflow-common/-/internal-non-workflow-common-1.0.0-rc.0.tgz",
+      "integrity": "sha512-BlOzY5QV2GJXHyHS36Xq0yCHoeFLk5bL4beV8IeUoH3YHhkGfh9qjtzQmR8/99eln3/hjzi9eFCaszoPkDjA3A==",
       "dependencies": {
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0"
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0"
       }
     },
     "node_modules/@temporalio/internal-workflow-common": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/internal-workflow-common/-/internal-workflow-common-0.21.0.tgz",
-      "integrity": "sha512-1Beoy0M4OOP+8WwYUPVpSTvYrYng8k0UAHgCTKZKJvPPgZS6rko+ZCplCEiaxK2MTPOTcwsu9lnzFaEYCWJrFQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/internal-workflow-common/-/internal-workflow-common-1.0.0-rc.0.tgz",
+      "integrity": "sha512-Q4ZcQC7Ovek9HU6Ap1Ir6w5MyOPZ0B/dtYRzJu/IYN4ivYdim4aPAFCmM4o3e9DDol313ZyMk9hgkzTOUJiKcQ==",
       "dependencies": {
-        "@temporalio/proto": "^0.21.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
         "long": "^4.0.0",
         "ms": "^2.1.3"
       }
@@ -636,9 +689,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@temporalio/proto": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-0.21.0.tgz",
-      "integrity": "sha512-TrsbaMMTBGkTkO2amrFImPzetYxBK3o/Cv4egfEddVGuBXuGu/DH1/mXOa3Hpxw6n5pCuiJDauL0TVyNuA5YCA==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.0.0-rc.0.tgz",
+      "integrity": "sha512-ATB2aszHkXb1oX74TQuFroiT273LITSE6NMjOYCMBfaR4IMpqlPYbmF559KE/flWYb52gptbUopQad+IGVKnag==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "long": "^4.0.0",
@@ -646,22 +699,21 @@
       }
     },
     "node_modules/@temporalio/worker": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-0.21.1.tgz",
-      "integrity": "sha512-MgJN9Y8nSNFVlHEHxETItPALlCk0/F1y7C93GwayXRgXTC05WEVmvfvHnYQR7v6hYfYiWjGNyRpBED1N8AtVwA==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.0.0-rc.0.tgz",
+      "integrity": "sha512-z8xxRNQC89zTBrepNMXZKUmjDzQwlMoqbYRmOU2FHpGHox+dPfSOxeQa1iDfImTRzpirCGLa9syY0NTtcMydbw==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.3",
         "@swc/core": "^1.2.152",
-        "@temporalio/activity": "^0.21.0",
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/core-bridge": "^0.21.1",
-        "@temporalio/internal-non-workflow-common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0",
-        "@temporalio/workflow": "^0.21.0",
+        "@temporalio/activity": "^1.0.0-rc.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/core-bridge": "^1.0.0-rc.0",
+        "@temporalio/internal-non-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
+        "@temporalio/workflow": "^1.0.0-rc.0",
         "abort-controller": "^3.0.0",
         "cargo-cp-artifact": "^0.1.4",
-        "dedent": "^0.7.0",
         "fs-extra": "^10.0.0",
         "heap-js": "^2.1.6",
         "memfs": "^3.2.2",
@@ -670,7 +722,10 @@
         "protobufjs": "^6.11.2",
         "rxjs": "^7.3.0",
         "semver": "^7.3.5",
+        "source-map": "^0.7.4",
+        "source-map-loader": "^3.0.1",
         "swc-loader": "^0.1.15",
+        "ts-dedent": "^2.2.0",
         "unionfs": "^4.4.0",
         "uuid": "^8.3.2",
         "webpack": "^5.51.1"
@@ -682,12 +737,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@temporalio/workflow": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-0.21.0.tgz",
-      "integrity": "sha512-hKMFY4YkzJWQPrcuAeQC/pI5Jq3GAFINMhS5f0/oHkYADSZs8/t/N7700XkDcMrMvJ/a2/iIRVNcj0MtT4XbiQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.0.0-rc.0.tgz",
+      "integrity": "sha512-1lOSjQ/EYcYgMdX6QNIoVjLp8Wst6/h6eI3+LTB3oubfGWXQeRQN5NR+ZwNZAd+/dNUo3X3uhzST0Tc1h73W5g==",
       "dependencies": {
-        "@temporalio/internal-workflow-common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0"
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -715,9 +771,9 @@
       "dev": true
     },
     "node_modules/@types/eslint": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
-      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.3.tgz",
+      "integrity": "sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -749,9 +805,9 @@
       "dev": true
     },
     "node_modules/@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
       "version": "17.0.10",
@@ -1307,6 +1363,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1403,9 +1464,9 @@
       }
     },
     "node_modules/arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -1463,9 +1524,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
+      "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1477,11 +1538,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001358",
+        "electron-to-chromium": "^1.4.164",
+        "node-releases": "^2.0.5",
+        "update-browserslist-db": "^1.0.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1505,9 +1565,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001358",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1628,11 +1688,6 @@
         }
       }
     },
-    "node_modules/dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1673,9 +1728,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.116",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.116.tgz",
-      "integrity": "sha512-sy2ol5DTH0sy8xvAglyHFxsNFXFsOBfa6rGmrtjiSdQOp53ossspduOzU+5Lx23H7GxEjjvtSF36XqkajV6Z5A=="
+      "version": "1.4.164",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.164.tgz",
+      "integrity": "sha512-K7iy5y6XyP9Pzh3uaDti0KC4JUNT6T1tLG5RTOmesqq2YgAJpYYYJ32m+anvZYjCV35llPTEh87kvEV/uSsiyQ=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2214,11 +2269,22 @@
       }
     },
     "node_modules/heap-js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.1.6.tgz",
-      "integrity": "sha512-xQxyJg7VcgveAZtY0eAu7iCn+2VCqLBkQoz7G4RnOIEsmP82J/LnRdr0I2Mi/pThkP5tviL8yFq5utE3yOPYpQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.2.0.tgz",
+      "integrity": "sha512-G3uM72G9F/zo9Hph/T7m4ZZVlVu5bx2f5CiCS78TBHz2mNIXnB5KRdEEYssXZJ7ldLDqID29bZ1D5ezCKQD2Zw==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -2378,10 +2444,10 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -2441,7 +2507,7 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2478,11 +2544,11 @@
       "dev": true
     },
     "node_modules/memfs": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.1.tgz",
-      "integrity": "sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.6.tgz",
+      "integrity": "sha512-rH9mjopto6Wkr7RFuH9l9dk3qb2XGOcYKr7xMhaYqfzuJqOqhRrcFvfD7JMuPj6SLmPreh5+6eAuv36NFAU+Mw==",
       "dependencies": {
-        "fs-monkey": "1.0.3"
+        "fs-monkey": "^1.0.3"
       },
       "engines": {
         "node": ">= 4.0.0"
@@ -2559,9 +2625,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2575,9 +2641,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -2698,17 +2764,17 @@
       }
     },
     "node_modules/proto3-json-serializer": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.8.tgz",
-      "integrity": "sha512-ACilkB6s1U1gWnl5jtICpnDai4VCxmI9GFxuEaYdxtDG2oVI3sVFIUsvUZcQbJgtPM6p+zqKbjTKQZp6Y4FpQw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+      "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
       "dependencies": {
         "protobufjs": "^6.11.2"
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2781,7 +2847,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2892,6 +2958,11 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/schema-utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -2979,11 +3050,39 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.1.tgz",
+      "integrity": "sha512-Vp1UsfyPvgujKQzi4pyDiTOnE3E4H+yHvkVRN3c/9PJmQS4CQJExvcDvaX/D+RV+xQben9HJ56jMJS3CgUeWyA==",
+      "dependencies": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/source-map-support": {
@@ -2993,6 +3092,14 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -3114,29 +3221,29 @@
       }
     },
     "node_modules/temporalio": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-0.21.1.tgz",
-      "integrity": "sha512-UHsrVmO/WkXoHj0KItA5uEaFxIUtQl6mhajdQsK90T3Ik02pBMjU3Zokttoo9BqC6sskyBG6ZpVcH4bDl2n+5Q==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-1.0.0-rc.0.tgz",
+      "integrity": "sha512-cHDATzTE/eFF80uorup50bbfVp57Viw/XOY/PaKX+KFnaqmJia6+VrVfPv3fqq25cZolNvmoBDd5FlIoxqnBEg==",
       "dependencies": {
-        "@temporalio/activity": "^0.21.0",
-        "@temporalio/client": "^0.21.0",
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0",
-        "@temporalio/worker": "^0.21.1",
-        "@temporalio/workflow": "^0.21.0"
+        "@temporalio/activity": "^1.0.0-rc.0",
+        "@temporalio/client": "^1.0.0-rc.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
+        "@temporalio/worker": "^1.0.0-rc.0",
+        "@temporalio/workflow": "^1.0.0-rc.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/terser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -3147,14 +3254,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
-      "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.7",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
         "terser": "^5.7.2"
       },
       "engines": {
@@ -3180,9 +3287,9 @@
       }
     },
     "node_modules/terser/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3194,14 +3301,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -3219,6 +3318,14 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-node": {
@@ -3371,6 +3478,31 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz",
+      "integrity": "sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3394,9 +3526,9 @@
       "dev": true
     },
     "node_modules/watchpack": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
-      "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -3406,9 +3538,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.72.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
-      "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
+      "version": "5.73.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
+      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -3419,13 +3551,13 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.2",
+        "enhanced-resolve": "^5.9.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.9",
-        "json-parse-better-errors": "^1.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
@@ -3460,9 +3592,9 @@
       }
     },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3698,14 +3830,14 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.9.tgz",
-      "integrity": "sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
+        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       }
     },
@@ -3725,6 +3857,49 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
+      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@microsoft/tsdoc": {
       "version": "0.13.2",
@@ -3771,14 +3946,14 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
-      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
@@ -3793,12 +3968,12 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -3807,27 +3982,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@swc/core": {
       "version": "1.2.168",
@@ -3928,25 +4103,25 @@
       "optional": true
     },
     "@temporalio/activity": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-0.21.0.tgz",
-      "integrity": "sha512-bGPX2RtjFnSD4q2Z0jQtjRomDY6wLFUjcTpnU1yMePqeG75RyUro7W+4H/82qBEchwX+Nwr1axdjumRBHVm0Rw==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.0.0-rc.0.tgz",
+      "integrity": "sha512-CKApbyvJF/fjPZf5ygEB9pjMtSmbZZ62NcIjtxqvRNAKe6lgrImeIQXK9kyb/CPCZBQCmaKvF+u7pVN9GLWHVw==",
       "requires": {
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
         "abort-controller": "^3.0.0"
       }
     },
     "@temporalio/client": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-0.21.0.tgz",
-      "integrity": "sha512-x6PIUc9/N7KxtWoa4yIJf3TixrwP3ff87kPg6e5LoWESWNkQis4fWhoLLFEYEYwX9WoPwjb4dmZ3RNGsG1nNqw==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.0.0-rc.0.tgz",
+      "integrity": "sha512-cSlMtUk5rt1jkfarcwn0ECl5pk7VtvcChamKKnNhvVf/K6wtE4b+GG0m6SzUwfIDPJhd/9JXGeXZ2b4i0QgAQg==",
       "requires": {
         "@grpc/grpc-js": "^1.5.7",
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/internal-non-workflow-common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-non-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
         "ms": "^2.1.3",
         "protobufjs": "^6.11.2",
         "uuid": "^8.3.2"
@@ -3960,41 +4135,42 @@
       }
     },
     "@temporalio/common": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-0.21.0.tgz",
-      "integrity": "sha512-VkxTJNOttwmNztucD0FhSntEzxwt1e8pW/x1dfzOkWGP7M5a7EH+gsoImqBlYBRR0ZWwYZPBiqV8UxDfR1pnLA==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.0.0-rc.0.tgz",
+      "integrity": "sha512-jlVoizIJ/ahOLO4L1e1XH+oZXAiMFQ51tNpL2+YNE9Y97ZEzoHYkHeO1e9qBVxxS3iW/4GvQFDSKFVdCO7DB3w==",
       "requires": {
-        "@temporalio/internal-workflow-common": "^0.21.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
         "proto3-json-serializer": "^0.1.6"
       }
     },
     "@temporalio/core-bridge": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-0.21.1.tgz",
-      "integrity": "sha512-jVJoqEiq1UEP47TJEIt7LekIviaf8fFV+9FVBbS+mX4vD9rqiaergLqy5SUYQnwFH28IaP3hMOLWBSja5GEgsg==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.0.0-rc.0.tgz",
+      "integrity": "sha512-+fm3U6/PhbJwkhnXIE3KCom+A9vzbqVuwayVPrcFB5ZLpx50aj7SJrWi9O6bPTEInrjySKtCTbVLvFBWfsfclw==",
       "requires": {
         "@opentelemetry/api": "^1.0.3",
-        "@temporalio/internal-non-workflow-common": "^0.21.0",
+        "@temporalio/internal-non-workflow-common": "^1.0.0-rc.0",
         "arg": "^5.0.1",
         "cargo-cp-artifact": "^0.1.4",
         "which": "^2.0.2"
       }
     },
     "@temporalio/internal-non-workflow-common": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/internal-non-workflow-common/-/internal-non-workflow-common-0.21.0.tgz",
-      "integrity": "sha512-Hl7SaS8fZXt/vxvCW+2IttEZSs7Zvi/3IWT4Gp7MvGF9L88CKoWUmN+yj+k8/xWMccM0/9+cMzAyOgjFv7e0ZQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/internal-non-workflow-common/-/internal-non-workflow-common-1.0.0-rc.0.tgz",
+      "integrity": "sha512-BlOzY5QV2GJXHyHS36Xq0yCHoeFLk5bL4beV8IeUoH3YHhkGfh9qjtzQmR8/99eln3/hjzi9eFCaszoPkDjA3A==",
       "requires": {
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0"
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0"
       }
     },
     "@temporalio/internal-workflow-common": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/internal-workflow-common/-/internal-workflow-common-0.21.0.tgz",
-      "integrity": "sha512-1Beoy0M4OOP+8WwYUPVpSTvYrYng8k0UAHgCTKZKJvPPgZS6rko+ZCplCEiaxK2MTPOTcwsu9lnzFaEYCWJrFQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/internal-workflow-common/-/internal-workflow-common-1.0.0-rc.0.tgz",
+      "integrity": "sha512-Q4ZcQC7Ovek9HU6Ap1Ir6w5MyOPZ0B/dtYRzJu/IYN4ivYdim4aPAFCmM4o3e9DDol313ZyMk9hgkzTOUJiKcQ==",
       "requires": {
-        "@temporalio/proto": "^0.21.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
         "long": "^4.0.0",
         "ms": "^2.1.3"
       },
@@ -4007,9 +4183,9 @@
       }
     },
     "@temporalio/proto": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-0.21.0.tgz",
-      "integrity": "sha512-TrsbaMMTBGkTkO2amrFImPzetYxBK3o/Cv4egfEddVGuBXuGu/DH1/mXOa3Hpxw6n5pCuiJDauL0TVyNuA5YCA==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.0.0-rc.0.tgz",
+      "integrity": "sha512-ATB2aszHkXb1oX74TQuFroiT273LITSE6NMjOYCMBfaR4IMpqlPYbmF559KE/flWYb52gptbUopQad+IGVKnag==",
       "requires": {
         "@types/long": "^4.0.1",
         "long": "^4.0.0",
@@ -4017,22 +4193,21 @@
       }
     },
     "@temporalio/worker": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-0.21.1.tgz",
-      "integrity": "sha512-MgJN9Y8nSNFVlHEHxETItPALlCk0/F1y7C93GwayXRgXTC05WEVmvfvHnYQR7v6hYfYiWjGNyRpBED1N8AtVwA==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.0.0-rc.0.tgz",
+      "integrity": "sha512-z8xxRNQC89zTBrepNMXZKUmjDzQwlMoqbYRmOU2FHpGHox+dPfSOxeQa1iDfImTRzpirCGLa9syY0NTtcMydbw==",
       "requires": {
         "@opentelemetry/api": "^1.0.3",
         "@swc/core": "^1.2.152",
-        "@temporalio/activity": "^0.21.0",
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/core-bridge": "^0.21.1",
-        "@temporalio/internal-non-workflow-common": "^0.21.0",
-        "@temporalio/internal-workflow-common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0",
-        "@temporalio/workflow": "^0.21.0",
+        "@temporalio/activity": "^1.0.0-rc.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/core-bridge": "^1.0.0-rc.0",
+        "@temporalio/internal-non-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
+        "@temporalio/workflow": "^1.0.0-rc.0",
         "abort-controller": "^3.0.0",
         "cargo-cp-artifact": "^0.1.4",
-        "dedent": "^0.7.0",
         "fs-extra": "^10.0.0",
         "heap-js": "^2.1.6",
         "memfs": "^3.2.2",
@@ -4041,7 +4216,10 @@
         "protobufjs": "^6.11.2",
         "rxjs": "^7.3.0",
         "semver": "^7.3.5",
+        "source-map": "^0.7.4",
+        "source-map-loader": "^3.0.1",
         "swc-loader": "^0.1.15",
+        "ts-dedent": "^2.2.0",
         "unionfs": "^4.4.0",
         "uuid": "^8.3.2",
         "webpack": "^5.51.1"
@@ -4055,12 +4233,13 @@
       }
     },
     "@temporalio/workflow": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-0.21.0.tgz",
-      "integrity": "sha512-hKMFY4YkzJWQPrcuAeQC/pI5Jq3GAFINMhS5f0/oHkYADSZs8/t/N7700XkDcMrMvJ/a2/iIRVNcj0MtT4XbiQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.0.0-rc.0.tgz",
+      "integrity": "sha512-1lOSjQ/EYcYgMdX6QNIoVjLp8Wst6/h6eI3+LTB3oubfGWXQeRQN5NR+ZwNZAd+/dNUo3X3uhzST0Tc1h73W5g==",
       "requires": {
-        "@temporalio/internal-workflow-common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0"
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/internal-workflow-common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0"
       }
     },
     "@tsconfig/node10": {
@@ -4088,9 +4267,9 @@
       "dev": true
     },
     "@types/eslint": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
-      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.3.tgz",
+      "integrity": "sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4122,9 +4301,9 @@
       "dev": true
     },
     "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
       "version": "17.0.10",
@@ -4504,6 +4683,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4568,9 +4752,9 @@
       }
     },
     "arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -4619,15 +4803,14 @@
       }
     },
     "browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
+      "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001358",
+        "electron-to-chromium": "^1.4.164",
+        "node-releases": "^2.0.5",
+        "update-browserslist-db": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -4642,9 +4825,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
+      "version": "1.0.30001358",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw=="
     },
     "cargo-cp-artifact": {
       "version": "0.1.6",
@@ -4726,11 +4909,6 @@
         "ms": "2.1.2"
       }
     },
-    "dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
-    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4762,9 +4940,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.116",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.116.tgz",
-      "integrity": "sha512-sy2ol5DTH0sy8xvAglyHFxsNFXFsOBfa6rGmrtjiSdQOp53ossspduOzU+5Lx23H7GxEjjvtSF36XqkajV6Z5A=="
+      "version": "1.4.164",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.164.tgz",
+      "integrity": "sha512-K7iy5y6XyP9Pzh3uaDti0KC4JUNT6T1tLG5RTOmesqq2YgAJpYYYJ32m+anvZYjCV35llPTEh87kvEV/uSsiyQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -5180,9 +5358,17 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "heap-js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.1.6.tgz",
-      "integrity": "sha512-xQxyJg7VcgveAZtY0eAu7iCn+2VCqLBkQoz7G4RnOIEsmP82J/LnRdr0I2Mi/pThkP5tviL8yFq5utE3yOPYpQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.2.0.tgz",
+      "integrity": "sha512-G3uM72G9F/zo9Hph/T7m4ZZVlVu5bx2f5CiCS78TBHz2mNIXnB5KRdEEYssXZJ7ldLDqID29bZ1D5ezCKQD2Zw=="
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
     },
     "ignore": {
       "version": "4.0.6",
@@ -5304,10 +5490,10 @@
         "esprima": "^4.0.0"
       }
     },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -5356,7 +5542,7 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -5390,11 +5576,11 @@
       "dev": true
     },
     "memfs": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.1.tgz",
-      "integrity": "sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.6.tgz",
+      "integrity": "sha512-rH9mjopto6Wkr7RFuH9l9dk3qb2XGOcYKr7xMhaYqfzuJqOqhRrcFvfD7JMuPj6SLmPreh5+6eAuv36NFAU+Mw==",
       "requires": {
-        "fs-monkey": "1.0.3"
+        "fs-monkey": "^1.0.3"
       }
     },
     "merge-stream": {
@@ -5453,9 +5639,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5469,9 +5655,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "once": {
       "version": "1.4.0",
@@ -5559,17 +5745,17 @@
       "dev": true
     },
     "proto3-json-serializer": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.8.tgz",
-      "integrity": "sha512-ACilkB6s1U1gWnl5jtICpnDai4VCxmI9GFxuEaYdxtDG2oVI3sVFIUsvUZcQbJgtPM6p+zqKbjTKQZp6Y4FpQw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+      "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
       "requires": {
         "protobufjs": "^6.11.2"
       }
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5614,7 +5800,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -5675,6 +5861,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "schema-utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -5734,9 +5925,24 @@
       }
     },
     "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "source-map-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.1.tgz",
+      "integrity": "sha512-Vp1UsfyPvgujKQzi4pyDiTOnE3E4H+yHvkVRN3c/9PJmQS4CQJExvcDvaX/D+RV+xQben9HJ56jMJS3CgUeWyA==",
+      "requires": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.1"
+      }
     },
     "source-map-support": {
       "version": "0.5.21",
@@ -5745,6 +5951,13 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "sprintf-js": {
@@ -5837,55 +6050,50 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "temporalio": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-0.21.1.tgz",
-      "integrity": "sha512-UHsrVmO/WkXoHj0KItA5uEaFxIUtQl6mhajdQsK90T3Ik02pBMjU3Zokttoo9BqC6sskyBG6ZpVcH4bDl2n+5Q==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-1.0.0-rc.0.tgz",
+      "integrity": "sha512-cHDATzTE/eFF80uorup50bbfVp57Viw/XOY/PaKX+KFnaqmJia6+VrVfPv3fqq25cZolNvmoBDd5FlIoxqnBEg==",
       "requires": {
-        "@temporalio/activity": "^0.21.0",
-        "@temporalio/client": "^0.21.0",
-        "@temporalio/common": "^0.21.0",
-        "@temporalio/proto": "^0.21.0",
-        "@temporalio/worker": "^0.21.1",
-        "@temporalio/workflow": "^0.21.0"
+        "@temporalio/activity": "^1.0.0-rc.0",
+        "@temporalio/client": "^1.0.0-rc.0",
+        "@temporalio/common": "^1.0.0-rc.0",
+        "@temporalio/proto": "^1.0.0-rc.0",
+        "@temporalio/worker": "^1.0.0-rc.0",
+        "@temporalio/workflow": "^1.0.0-rc.0"
       }
     },
     "terser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
         },
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
-      "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
       "requires": {
+        "@jridgewell/trace-mapping": "^0.3.7",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
         "terser": "^5.7.2"
       }
     },
@@ -5903,6 +6111,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="
     },
     "ts-node": {
       "version": "10.4.0",
@@ -6006,6 +6219,15 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
+    "update-browserslist-db": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz",
+      "integrity": "sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6026,18 +6248,18 @@
       "dev": true
     },
     "watchpack": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
-      "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
     },
     "webpack": {
-      "version": "5.72.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
-      "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
+      "version": "5.73.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
+      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -6048,13 +6270,13 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.2",
+        "enhanced-resolve": "^5.9.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.9",
-        "json-parse-better-errors": "^1.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
@@ -6066,9 +6288,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
         },
         "acorn-import-assertions": {
           "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "commander": "^8.3.0",
-    "temporalio": "latest",
+    "temporalio": "1.0.0-rc.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "commander": "^8.3.0",
-    "temporalio": "0.21.1",
+    "temporalio": "latest",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- Remove unused `--node-modules-path` CLI option
- Use `latest` version of `temporalio` to keep up-to-date
- Upgrade to support breaking changes in TS SDK `main` branch