### PR TITLE
Command to "prepare" (i.e. prebuild) SDK directories to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ language in this repository.
 Several other options are available, some of which are described below. Run `sdk-features run --help` to see all
 options.
 
+### Preparing
+
+By default when using `run` and a version, a temporary directory is created with a temporary project, the project is
+built, and then the features are run. To separate the steps, the `prepare` command can be used to prebuild the project
+in a directory. Then `run` can use the `--prepared-dir` to reference that directory.
+
+The command to prepare is:
+
+    sdk-features prepare --lang LANG --version VERSION --dir DIR
+
+The version is required and the directory is a simple string name of a not-yet-existing directory to be created directly
+beneath this SDK features directory. That same directory value can then be provided as `--prepared-dir` to `run`. When
+using a prepared directory on `run`, a version cannot be specified.
+
 ### External Server and Namespace
 
 By default, a [temporalite](https://github.com/DataDog/temporalite) is dynamically started at runtime to handle all

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.jayway.jsonpath:json-path:2.6.0'
     implementation 'info.picocli:picocli:4.6.2'
-    implementation 'io.temporal:temporal-sdk:1.5.0'
+    implementation 'io.temporal:temporal-sdk:1.14.0'
     implementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     implementation 'org.reflections:reflections:0.10.2'
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -18,6 +18,7 @@ func Execute() {
 func NewApp() *cli.App {
 	return &cli.App{
 		Commands: []*cli.Command{
+			prepareCmd(),
 			runCmd(),
 		},
 	}

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+	"go.temporal.io/server/common/log"
+)
+
+func prepareCmd() *cli.Command {
+	var config PrepareConfig
+	return &cli.Command{
+		Name:  "prepare",
+		Usage: "prepare an SDK for execution",
+		Flags: config.flags(),
+		Action: func(ctx *cli.Context) error {
+			return NewPreparer(config).Prepare(ctx.Context)
+		},
+	}
+}
+
+// PrepareConfig is configuration for NewPreparer.
+type PrepareConfig struct {
+	Dir     string
+	Lang    string
+	Version string
+}
+
+func (p *PrepareConfig) flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name: "dir",
+			Usage: "Directory name to prepare SDK for run at. " +
+				"This will be relative to the SDK features directory and cannot exist yet.",
+			Required:    true,
+			Destination: &p.Dir,
+		},
+		&cli.StringFlag{
+			Name:        "lang",
+			Usage:       "SDK language to run ('go' or 'java' or 'ts' or 'py')",
+			Required:    true,
+			Destination: &p.Lang,
+		},
+		&cli.StringFlag{
+			Name:        "version",
+			Usage:       "SDK language version to run. Most languages support versions as paths.",
+			Required:    true,
+			Destination: &p.Version,
+		},
+	}
+}
+
+type Preparer struct {
+	log     log.Logger
+	config  PrepareConfig
+	rootDir string
+}
+
+func NewPreparer(config PrepareConfig) *Preparer {
+	return &Preparer{
+		// TODO(cretz): Configurable logger
+		log:     log.NewCLILogger(),
+		config:  config,
+		rootDir: rootDir(),
+	}
+}
+
+func (p *Preparer) Prepare(ctx context.Context) error {
+	var err error
+	if p.config.Lang, err = normalizeLangName(p.config.Lang); err != nil {
+		return err
+	} else if p.config.Dir == "" {
+		return fmt.Errorf("directory required")
+	} else if strings.ContainsAny(p.config.Dir, `\/`) {
+		return fmt.Errorf("directory must not have path separators, it is always relative to the SDK features root")
+	} else if p.config.Version == "" {
+		return fmt.Errorf("version required")
+	}
+
+	// Qualify the directory, error if it already exists. Since we're setting
+	// things up in this temporary directory, it is unreasonable to auto-clean or
+	// merge, so we just error if already there.
+	p.config.Dir = filepath.Join(p.rootDir, p.config.Dir)
+	if err := os.Mkdir(p.config.Dir, 0755); err != nil {
+		return fmt.Errorf("failed creating directory: %w", err)
+	}
+
+	// Go
+	switch p.config.Lang {
+	case "go":
+		return p.PrepareGoExternal(ctx)
+	case "java":
+		// Prepare and build
+		return p.PrepareJavaExternal(ctx, true)
+	case "ts":
+		return p.PrepareTypeScriptExternal(ctx)
+	case "py":
+		return p.PreparePythonExternal(ctx)
+	default:
+		return fmt.Errorf("unrecognized language")
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -36,15 +37,12 @@ func runCmd() *cli.Command {
 
 // RunConfig is configuration for NewRunner.
 type RunConfig struct {
-	Lang                string
-	Version             string
+	PrepareConfig
+	Server              string
+	Namespace           string
 	GenerateHistory     bool
 	DisableHistoryCheck bool
-	// If not set, defaults to creating one
-	Server string
-	// Defaults to unique value
-	Namespace     string
-	RetainTempDir bool
+	RetainTempDir       bool
 }
 
 func (r *RunConfig) flags() []cli.Flag {
@@ -85,6 +83,11 @@ func (r *RunConfig) flags() []cli.Flag {
 			Usage:       "Do not delete the temp directory after the run",
 			Destination: &r.RetainTempDir,
 		},
+		&cli.StringFlag{
+			Name:        "prepared-dir",
+			Usage:       "Relative directory already prepared. Cannot include version with this.",
+			Destination: &r.Dir,
+		},
 	}
 }
 
@@ -113,21 +116,28 @@ func NewRunner(config RunConfig) *Runner {
 // Run runs all matching features for the given patterns (or all if no patterns
 // given).
 func (r *Runner) Run(ctx context.Context, patterns []string) error {
-	switch r.config.Lang {
-	case "go", "java", "ts", "py":
-		// Allow the full typescript or python word, but we need to match the file
-		// extension for the rest of run
-	case "typescript":
-		r.config.Lang = "ts"
-	case "python":
-		r.config.Lang = "py"
-	default:
-		return fmt.Errorf("invalid language %q, must be one of: go or java or ts or py", r.config.Lang)
+	var err error
+	if r.config.Lang, err = normalizeLangName(r.config.Lang); err != nil {
+		return err
 	}
 
 	// Cannot generate history if a version isn't provided explicitly
 	if r.config.GenerateHistory && r.config.Version == "" {
 		return fmt.Errorf("must have explicit version to generate history")
+	}
+
+	// If prepared dir given, validate and make absolute
+	if r.config.Dir != "" {
+		if strings.ContainsAny(r.config.Dir, `\/`) {
+			return fmt.Errorf("prepared directory must not have path separators, it is always relative to the SDK features root")
+		} else if r.config.Version != "" {
+			return fmt.Errorf("cannot provide version with prepared directory")
+		}
+		// Make the dir absolute
+		r.config.Dir = filepath.Join(r.rootDir, r.config.Dir)
+		if _, err := os.Stat(r.config.Dir); err != nil {
+			return fmt.Errorf("failed checking prepared directory: %w", err)
+		}
 	}
 
 	// If the namespace is not set, set it ourselves
@@ -321,4 +331,19 @@ func (r *Runner) destroyTempDir() {
 	if r.createdTempDir != nil {
 		_ = os.RemoveAll(*r.createdTempDir)
 	}
+}
+
+func normalizeLangName(lang string) (string, error) {
+	switch lang {
+	case "go", "java", "ts", "py":
+		// Allow the full typescript or python word, but we need to match the file
+		// extension for the rest of run
+	case "typescript":
+		lang = "ts"
+	case "python":
+		lang = "py"
+	default:
+		return "", fmt.Errorf("invalid language %q, must be one of: go or java or ts or py", lang)
+	}
+	return lang, nil
 }

--- a/cmd/run_go.go
+++ b/cmd/run_go.go
@@ -13,19 +13,11 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-// RunGoExternal runs the given run details in an external Go project. This
-// expects the server to already be started.
-func (r *Runner) RunGoExternal(ctx context.Context, run *cmd.Run) error {
-	// To do this, we are going to create a separate project with the proper SDK
-	// version included and a simple main.go file that executes the local runner
-
-	// Create base dir
-	tempDir, err := os.MkdirTemp(r.rootDir, "sdk-features-go-test-")
-	if err != nil {
-		return fmt.Errorf("failed creating temp dir: %w", err)
-	}
-	r.createdTempDir = &tempDir
-	r.log.Info("Building temporary Go project", tag.NewStringTag("Path", tempDir))
+// PrepareGoExternal prepares a Go run without running it. The preparer config
+// directory is expected to be an absolute subdirectory just beneath the root
+// directory.
+func (p *Preparer) PrepareGoExternal(ctx context.Context) error {
+	p.log.Info("Preparing Go project", tag.NewStringTag("Path", p.config.Dir))
 
 	// Create go.mod
 	goMod := `module go.temporal.io/sdk-features-test
@@ -40,23 +32,23 @@ func (r *Runner) RunGoExternal(ctx context.Context, run *cmd.Run) error {
 	
 	replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client v3.2.1+incompatible`
 	// If a version is specified, overwrite the SDK to use that
-	if r.config.Version != "" {
+	if p.config.Version != "" {
 		// If version does not start with a "v" we assume path
-		if strings.HasPrefix(r.config.Version, "v") {
-			goMod += "\nreplace go.temporal.io/sdk => go.temporal.io/sdk " + r.config.Version
+		if strings.HasPrefix(p.config.Version, "v") {
+			goMod += "\nreplace go.temporal.io/sdk => go.temporal.io/sdk " + p.config.Version
 		} else {
-			absVersion, err := filepath.Abs(r.config.Version)
+			absVersion, err := filepath.Abs(p.config.Version)
 			if err != nil {
 				return fmt.Errorf("version does not start with 'v' and cannot get abs dir: %w", err)
 			}
-			relVersion, err := filepath.Rel(tempDir, absVersion)
+			relVersion, err := filepath.Rel(p.config.Dir, absVersion)
 			if err != nil {
 				return fmt.Errorf("version does not start with 'v' and unable to relativize: %w", err)
 			}
 			goMod += "\nreplace go.temporal.io/sdk => " + filepath.ToSlash(relVersion)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goMod), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(p.config.Dir, "go.mod"), []byte(goMod), 0644); err != nil {
 		return fmt.Errorf("failed writing go.mod: %w", err)
 	}
 
@@ -71,13 +63,13 @@ import (
 func main() {
 	cmd.Execute()
 }`
-	if err := os.WriteFile(filepath.Join(tempDir, "main.go"), []byte(mainGo), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(p.config.Dir, "main.go"), []byte(mainGo), 0644); err != nil {
 		return fmt.Errorf("failed writing main.go: %w", err)
 	}
 
 	// Tidy it
 	goCmd := exec.CommandContext(ctx, "go", "mod", "tidy")
-	goCmd.Dir = tempDir
+	goCmd.Dir = p.config.Dir
 	goCmd.Stdin, goCmd.Stdout, goCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := goCmd.Run(); err != nil {
 		return fmt.Errorf("failed go mod tidy: %w", err)
@@ -89,25 +81,52 @@ func main() {
 		exe += ".exe"
 	}
 	goCmdArgs := []string{"build", "-o", exe}
-	for _, tag := range cmd.GoBuildTags(r.config.Version) {
+	for _, tag := range cmd.GoBuildTags(p.config.Version) {
 		goCmdArgs = append(goCmdArgs, "-tags", tag)
 	}
 	goCmd = exec.CommandContext(ctx, "go", goCmdArgs...)
-	goCmd.Dir = tempDir
+	goCmd.Dir = p.config.Dir
 	goCmd.Stdin, goCmd.Stdout, goCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := goCmd.Run(); err != nil {
 		return fmt.Errorf("failed go build: %w", err)
 	}
 
+	return nil
+}
+
+// RunGoExternal runs the given run details in an external Go project. This
+// expects the server to already be started.
+func (r *Runner) RunGoExternal(ctx context.Context, run *cmd.Run) error {
+	// To do this, we are going to create a separate project with the proper SDK
+	// version included and a simple main.go file that executes the local runner
+
+	// If there is not a prepared directory, create a temp directory and prepare
+	if r.config.Dir == "" {
+		var err error
+		if r.config.Dir, err = os.MkdirTemp(r.rootDir, "sdk-features-go-test-"); err != nil {
+			return fmt.Errorf("failed creating temp dir: %w", err)
+		}
+		r.createdTempDir = &r.config.Dir
+
+		// Prepare the project
+		if err := NewPreparer(r.config.PrepareConfig).PrepareGoExternal(ctx); err != nil {
+			return err
+		}
+	}
+
 	// Run it with args and features appended.
+	exe := "sdk-features-test"
+	if runtime.GOOS == "windows" {
+		exe += ".exe"
+	}
 	runArgs := append([]string{
 		"run",
 		"--server", r.config.Server,
 		"--namespace", r.config.Namespace,
 	}, run.ToArgs()...)
 	r.log.Debug("Running Go separately", tag.NewStringsTag("Args", runArgs))
-	goCmd = exec.CommandContext(ctx, filepath.Join(tempDir, exe), runArgs...)
-	goCmd.Dir = tempDir
+	goCmd := exec.CommandContext(ctx, filepath.Join(r.config.Dir, exe), runArgs...)
+	goCmd.Dir = r.config.Dir
 	goCmd.Stdin, goCmd.Stdout, goCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := goCmd.Run(); err != nil {
 		return fmt.Errorf("failed running: %w", err)

--- a/cmd/run_java.go
+++ b/cmd/run_java.go
@@ -10,27 +10,22 @@ import (
 	"strings"
 
 	"go.temporal.io/sdk-features/harness/go/cmd"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 )
 
-// RunJavaExternal runs the Java run in an external process. This expects the
-// server to already be started.
-func (r *Runner) RunJavaExternal(ctx context.Context, run *cmd.Run) error {
+// PrepareJavaExternal prepares a Java run without running it. The preparer
+// config directory is expected to be an absolute subdirectory just beneath the
+// root directory.
+func (p *Preparer) PrepareJavaExternal(ctx context.Context, build bool) error {
 	// To do this, we're gonna create a temporary project, --include-build this
-	// one, then "gradle run" it
-
-	// Create base dir
-	tempDir, err := os.MkdirTemp(r.rootDir, "sdk-features-java-test-")
-	if err != nil {
-		return fmt.Errorf("failed creating temp dir: %w", err)
-	}
-	r.createdTempDir = &tempDir
-	r.log.Info("Building temporary Java project", tag.NewStringTag("Path", tempDir))
+	// one, then gradle it
+	p.log.Info("Building Java project", tag.NewStringTag("Path", p.config.Dir))
 
 	// Create build.gradle and settings.gradle
 	temporalSDKDependency := ""
-	if r.config.Version != "" {
-		temporalSDKDependency = fmt.Sprintf("implementation 'io.temporal:temporal-sdk:%v'", r.config.Version)
+	if p.config.Version != "" {
+		temporalSDKDependency = fmt.Sprintf("implementation 'io.temporal:temporal-sdk:%v'", p.config.Version)
 	}
 	buildGradle := `
 plugins {
@@ -49,12 +44,38 @@ dependencies {
 application {
     mainClass = 'io.temporal.sdkfeatures.Main'
 }`
-	if err := os.WriteFile(filepath.Join(tempDir, "build.gradle"), []byte(buildGradle), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(p.config.Dir, "build.gradle"), []byte(buildGradle), 0644); err != nil {
 		return fmt.Errorf("failed writing build.gradle: %w", err)
 	}
-	settingsGradle := fmt.Sprintf("rootProject.name = '%v'", filepath.Base(tempDir))
-	if err := os.WriteFile(filepath.Join(tempDir, "settings.gradle"), []byte(settingsGradle), 0644); err != nil {
+	settingsGradle := fmt.Sprintf("rootProject.name = '%v'", filepath.Base(p.config.Dir))
+	if err := os.WriteFile(filepath.Join(p.config.Dir, "settings.gradle"), []byte(settingsGradle), 0644); err != nil {
 		return fmt.Errorf("failed writing settings.gradle: %w", err)
+	}
+
+	// Build if wanted
+	if build {
+		// This is really only to prime the system-level caches. The build won't be
+		// used by run.
+		return runGradle(ctx, p.log, p.config.Dir, []string{"--no-daemon", "--include-build", "../", "build"})
+	}
+	return nil
+}
+
+// RunJavaExternal runs the Java run in an external process. This expects the
+// server to already be started.
+func (r *Runner) RunJavaExternal(ctx context.Context, run *cmd.Run) error {
+	// Create temp dir if needed and prepare the project
+	if r.config.Dir == "" {
+		var err error
+		if r.config.Dir, err = os.MkdirTemp(r.rootDir, "sdk-features-java-test-"); err != nil {
+			return fmt.Errorf("failed creating temp dir: %w", err)
+		}
+		r.createdTempDir = &r.config.Dir
+
+		// Prepare the project but don't build since it'll happen when we run later
+		if err := NewPreparer(r.config.PrepareConfig).PrepareJavaExternal(ctx, false); err != nil {
+			return err
+		}
 	}
 
 	// Prepare args for gradle run. Gradle args will be single quoted or double
@@ -71,22 +92,27 @@ application {
 		}
 		runArgsStr += "'" + runArg + "'"
 	}
-	exeArgs := []string{"--include-build", "../", "run", "--args", runArgsStr}
 
+	// Run. We aren't using some previous prepared build or anything. Rather
+	// preparing is just for priming the Gradle cache.
+	return runGradle(ctx, r.log, r.config.Dir, []string{"--include-build", "../", "run", "--args", runArgsStr})
+}
+
+func runGradle(ctx context.Context, log log.Logger, dir string, args []string) error {
 	// Prepare exe whether windows or not
 	var exe string
 	if runtime.GOOS == "windows" {
 		exe = "cmd.exe"
-		exeArgs = append([]string{"/C", "..\\gradlew"}, exeArgs...)
+		args = append([]string{"/C", "..\\gradlew"}, args...)
 	} else {
 		exe = "/bin/sh"
-		exeArgs = append([]string{"../gradlew"}, exeArgs...)
+		args = append([]string{"../gradlew"}, args...)
 	}
 
 	// Run
-	r.log.Debug("Running Gradle separately", tag.NewStringTag("Exe", exe), tag.NewStringsTag("Args", exeArgs))
-	cmd := exec.CommandContext(ctx, exe, exeArgs...)
-	cmd.Dir = tempDir
+	log.Debug("Running Gradle separately", tag.NewStringTag("Exe", exe), tag.NewStringsTag("Args", args))
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Dir = dir
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed running: %w", err)

--- a/cmd/run_python.go
+++ b/cmd/run_python.go
@@ -14,47 +14,35 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-// RunPythonExternal runs the Python run in an external process. This expects
-// the server to already be started.
-func (r *Runner) RunPythonExternal(ctx context.Context, run *cmd.Run) error {
-	// To do this, if they supplied a custom version we'll make a temporary
-	// directory to run in with a custom pyproject and such. Otherwise we'll just
-	// use this directory.
-
-	runDir := r.rootDir
-	r.log.Info("Python version selected: " + r.config.Version)
-	if r.config.Version != "" {
-		// Put pyproject.toml in temp dir
-		var err error
-		if runDir, err = os.MkdirTemp(r.rootDir, "sdk-features-python-test-"); err != nil {
-			return fmt.Errorf("failed creating temp dir: %w", err)
+// PreparePythonExternal prepares a Python run without running it. The preparer
+// config directory is expected to be an absolute subdirectory just beneath the
+// root directory.
+func (p *Preparer) PreparePythonExternal(ctx context.Context) error {
+	p.log.Info("Building Python project", tag.NewStringTag("Path", p.config.Dir))
+	// Use semantic version or path if it's a path
+	versionStr := strconv.Quote(p.config.Version)
+	if strings.ContainsAny(p.config.Version, "/\\") {
+		// We expect a dist/ directory with a single whl file present
+		wheels, err := filepath.Glob(filepath.Join(p.config.Version, "dist/*.whl"))
+		if err != nil {
+			return fmt.Errorf("failed glob wheel lookup: %w", err)
+		} else if len(wheels) != 1 {
+			return fmt.Errorf("expected single dist wheel, found %v", len(wheels))
 		}
-		r.createdTempDir = &runDir
-		r.log.Info("Building temporary Python project", tag.NewStringTag("Path", runDir))
-		// Use semantic version or path if it's a path
-		versionStr := strconv.Quote(r.config.Version)
-		if strings.ContainsAny(r.config.Version, "/\\") {
-			// We expect a dist/ directory with a single whl file present
-			wheels, err := filepath.Glob(filepath.Join(r.config.Version, "dist/*.whl"))
-			if err != nil {
-				return fmt.Errorf("failed glob wheel lookup: %w", err)
-			} else if len(wheels) != 1 {
-				return fmt.Errorf("expected single dist wheel, found %v", len(wheels))
-			}
-			absWheel, err := filepath.Abs(wheels[0])
-			if err != nil {
-				return fmt.Errorf("unable to make wheel path absolute: %w", err)
-			}
-			// There's a strange bug in Poetry or somewhere deeper where, on Windows,
-			// the single drive letter has to be capitalized
-			if runtime.GOOS == "windows" && absWheel[1] == ':' {
-				absWheel = strings.ToUpper(absWheel[:1]) + absWheel[1:]
-			}
-			versionStr = "{ path = " + strconv.Quote(absWheel) + " }"
+		absWheel, err := filepath.Abs(wheels[0])
+		if err != nil {
+			return fmt.Errorf("unable to make wheel path absolute: %w", err)
 		}
-		pyProjectTOML := `
+		// There's a strange bug in Poetry or somewhere deeper where, on Windows,
+		// the single drive letter has to be capitalized
+		if runtime.GOOS == "windows" && absWheel[1] == ':' {
+			absWheel = strings.ToUpper(absWheel[:1]) + absWheel[1:]
+		}
+		versionStr = "{ path = " + strconv.Quote(absWheel) + " }"
+	}
+	pyProjectTOML := `
 [tool.poetry]
-name = "sdk-features-python-test-` + filepath.Base(runDir) + `"
+name = "sdk-features-python-test-` + filepath.Base(p.config.Dir) + `"
 version = "0.1.0"
 description = "Temporal SDK Features Python Test"
 authors = ["Temporal Technologies Inc <sdk@temporal.io>"]
@@ -67,17 +55,40 @@ sdk-features = { path = "../" }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"`
-		if err := os.WriteFile(filepath.Join(runDir, "pyproject.toml"), []byte(pyProjectTOML), 0644); err != nil {
-			return fmt.Errorf("failed writing pyproject.toml: %w", err)
-		}
+	if err := os.WriteFile(filepath.Join(p.config.Dir, "pyproject.toml"), []byte(pyProjectTOML), 0644); err != nil {
+		return fmt.Errorf("failed writing pyproject.toml: %w", err)
+	}
 
-		// Install
-		cmd := exec.CommandContext(ctx, "poetry", "install", "--no-dev", "--no-root", "-v")
-		cmd.Dir = runDir
-		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed installing: %w", err)
+	// Install
+	cmd := exec.CommandContext(ctx, "poetry", "install", "--no-dev", "--no-root", "-v")
+	cmd.Dir = p.config.Dir
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed installing: %w", err)
+	}
+	return nil
+}
+
+// RunPythonExternal runs the Python run in an external process. This expects
+// the server to already be started.
+func (r *Runner) RunPythonExternal(ctx context.Context, run *cmd.Run) error {
+	// Create temp directory and prepare if using specific version
+	if r.config.Version != "" && r.config.Dir == "" {
+		// Create a temp directory and prepare
+		var err error
+		if r.config.Dir, err = os.MkdirTemp(r.rootDir, "sdk-features-python-test-"); err != nil {
+			return fmt.Errorf("failed creating temp dir: %w", err)
 		}
+		r.createdTempDir = &r.config.Dir
+		if err := NewPreparer(r.config.PrepareConfig).PrepareTypeScriptExternal(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Run in this directory unless we have prepared directory already
+	runDir := r.rootDir
+	if r.config.Dir != "" {
+		runDir = r.config.Dir
 	}
 
 	// Run

--- a/cmd/run_typescript.go
+++ b/cmd/run_typescript.go
@@ -25,18 +25,13 @@ type packageJsonTemporalVersion struct {
 	Dependencies struct{ Temporalio string }
 }
 
-// RunTypeScriptExternal runs the TS harness in an external process. This expects the
-// server to already be started.
-func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error {
-	// Create base dir
-	tempDir, err := os.MkdirTemp(r.rootDir, "sdk-features-typescript-test-")
-	if err != nil {
-		return fmt.Errorf("failed creating temp dir: %w", err)
-	}
-	r.createdTempDir = &tempDir
-	r.log.Info("Building temporary Typescript project", tag.NewStringTag("Path", tempDir))
+// PrepareTypeScriptExternal prepares a TypeScript run without running it. The
+// preparer config directory is expected to be an absolute subdirectory just
+// beneath the root directory.
+func (p *Preparer) PrepareTypeScriptExternal(ctx context.Context) error {
+	p.log.Info("Building Typescript project", tag.NewStringTag("Path", p.config.Dir))
 
-	harnessPath, err := filepath.Abs(filepath.Join(r.rootDir, "harness", "ts"))
+	harnessPath, err := filepath.Abs(filepath.Join(p.rootDir, "harness", "ts"))
 	if err != nil {
 		return fmt.Errorf("failed to make absolute path for TS harness: %w", err)
 	}
@@ -49,20 +44,23 @@ func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error 
 	var packageJSONEvaluated bytes.Buffer
 	localSDK := ""
 	MetaPkgVersion := ""
-	if strings.HasPrefix(r.config.Version, "/") {
-		localSDK = r.config.Version
+	if strings.HasPrefix(p.config.Version, "/") {
+		localSDK = p.config.Version
 	} else {
-		if r.config.Version == "" {
+		if p.config.Version == "" {
 			// Default to version from top-level package.json
-			packageJsonBytes, err := os.ReadFile(filepath.Join(r.rootDir, "package.json"))
+			packageJsonBytes, err := os.ReadFile(filepath.Join(p.rootDir, "package.json"))
+			if err != nil {
+				return fmt.Errorf("failed reading package.json: %w", err)
+			}
 			verStruct := packageJsonTemporalVersion{}
 			err = json.Unmarshal(packageJsonBytes, &verStruct)
 			if err != nil {
 				return fmt.Errorf("failed read top level package.json: %w", err)
 			}
-			r.config.Version = verStruct.Dependencies.Temporalio
+			p.config.Version = verStruct.Dependencies.Temporalio
 		}
-		MetaPkgVersion = r.config.Version
+		MetaPkgVersion = p.config.Version
 	}
 	var maybeLocalSDK string
 	if localSDK != "" {
@@ -76,7 +74,7 @@ func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error 
 	if err != nil {
 		return fmt.Errorf("failed build package.json template: %w", err)
 	}
-	err = os.WriteFile(filepath.Join(tempDir, "package.json"), packageJSONEvaluated.Bytes(), 0644)
+	err = os.WriteFile(filepath.Join(p.config.Dir, "package.json"), packageJSONEvaluated.Bytes(), 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write to package.json in harness: %w", err)
 	}
@@ -86,7 +84,7 @@ func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error 
 	if err != nil {
 		return fmt.Errorf("failed open tsconfig.json template: %w", err)
 	}
-	err = os.WriteFile(filepath.Join(tempDir, "tsconfig.json"), tsConfigSrc, 0644)
+	err = os.WriteFile(filepath.Join(p.config.Dir, "tsconfig.json"), tsConfigSrc, 0644)
 	if err != nil {
 		return fmt.Errorf("failed create tsconfig.json in harness: %w", err)
 	}
@@ -95,7 +93,7 @@ func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error 
 
 	// Run npm install
 	npmCmd := exec.CommandContext(ctx, "npm", "install")
-	npmCmd.Dir = tempDir
+	npmCmd.Dir = p.config.Dir
 	npmCmd.Stdin, npmCmd.Stdout, npmCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := npmCmd.Run(); err != nil {
 		return fmt.Errorf("failed running npm install: %w", err)
@@ -103,10 +101,29 @@ func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error 
 
 	// Compile typescript
 	npmCmd = exec.CommandContext(ctx, "npm", "run", "build")
-	npmCmd.Dir = tempDir
+	npmCmd.Dir = p.config.Dir
 	npmCmd.Stdin, npmCmd.Stdout, npmCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := npmCmd.Run(); err != nil {
 		return fmt.Errorf("failed running npm run build: %w", err)
+	}
+	return nil
+}
+
+// RunTypeScriptExternal runs the TS harness in an external process. This expects the
+// server to already be started.
+func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error {
+	// If there is not a prepared directory, create a temp directory and prepare
+	if r.config.Dir == "" {
+		var err error
+		if r.config.Dir, err = os.MkdirTemp(r.rootDir, "sdk-features-typescript-test-"); err != nil {
+			return fmt.Errorf("failed creating temp dir: %w", err)
+		}
+		r.createdTempDir = &r.config.Dir
+
+		// Prepare the project
+		if err := NewPreparer(r.config.PrepareConfig).PrepareTypeScriptExternal(ctx); err != nil {
+			return err
+		}
 	}
 
 	// Run the harness
@@ -114,7 +131,7 @@ func (r *Runner) RunTypeScriptExternal(ctx context.Context, run *cmd.Run) error 
 		"--server", r.config.Server, "--namespace", r.config.Namespace}
 	runArgs = append(runArgs, run.ToArgs()...)
 	npmRun := exec.CommandContext(ctx, "npm", runArgs...)
-	npmRun.Dir = tempDir
+	npmRun.Dir = r.config.Dir
 	npmRun.Stdin, npmRun.Stdout, npmRun.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if err := npmRun.Run(); err != nil {
 		return fmt.Errorf("failed running ts harness: %w", err)

--- a/harness/java/io/temporal/sdkfeatures/Runner.java
+++ b/harness/java/io/temporal/sdkfeatures/Runner.java
@@ -28,10 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 public class Runner implements Closeable {
   private static final Logger log = LoggerFactory.getLogger(Main.class);
@@ -80,9 +77,11 @@ public class Runner implements Closeable {
       feature.workerOptions(workerBuild);
       worker = workerFactory.newWorker(config.taskQueue, workerBuild.build());
 
-      // Register workflow class and activity impl
+      // Register workflow class
       worker.registerWorkflowImplementationTypes(featureInfo.factoryClass);
-      if(feature.getClass().isAnnotationPresent(ActivityInterface.class)) {
+
+      // Register activity impl if any direct interfaces have the annotation
+      if (Arrays.stream(feature.getClass().getInterfaces()).anyMatch(i -> i.isAnnotationPresent(ActivityInterface.class))) {
         worker.registerActivitiesImplementations(feature);
       }
 

--- a/harness/python/main.py
+++ b/harness/python/main.py
@@ -3,9 +3,9 @@ import asyncio
 import importlib
 import logging
 from pathlib import Path
-from typing import List, Optional, cast
+from typing import List, cast
 
-from harness.python.feature import Feature, Runner, features
+from harness.python.feature import Runner, features
 
 logger = logging.getLogger(__name__)
 
@@ -44,12 +44,9 @@ async def run():
         if rel_dir not in features:
             raise ValueError(f"Cannot find registered feature for {rel_dir}")
         # Run
-        address = args.server
-        if "://" not in address:
-            address = f"http://{address}"
         try:
             await Runner(
-                address=address,
+                address=args.server,
                 namespace=args.namespace,
                 task_queue=task_queue,
                 feature=features[rel_dir],

--- a/poetry.lock
+++ b/poetry.lock
@@ -162,7 +162,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "temporalio"
-version = "0.1a2"
+version = "0.1b1"
 description = "Temporal.io Python SDK"
 category = "main"
 optional = false
@@ -170,10 +170,13 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 dacite = ">=1.6.0,<2.0.0"
-grpcio = ">=1.46.3,<2.0.0"
+grpcio = ">=1.47.0,<2.0.0"
 protobuf = ">=3.20.1,<4.0.0"
 types-protobuf = ">=3.19.21,<4.0.0"
 typing-extensions = ">=4.2.0,<5.0.0"
+
+[package.extras]
+opentelemetry = ["opentelemetry-api (>=1.11.1,<2.0.0)", "opentelemetry-sdk (>=1.11.1,<2.0.0)"]
 
 [[package]]
 name = "tomli"
@@ -222,215 +225,25 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6dfae52dcb0de818479b2597e1fdb8cae78e0bd918d7980e1f76189234efa0cd"
+content-hash = "26d6fc2e22b898f50854d03a39796b1c0675c6025af34d11b270a29665b3784f"
 
 [metadata.files]
-black = [
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
-    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
-    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
-    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
-    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
-    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
-    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
-    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
-    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
-    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
-    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
-    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
-    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
-    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
-    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
-    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
-    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
-    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
-]
-click = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
-]
-colorama = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
-]
-dacite = [
-    {file = "dacite-1.6.0-py3-none-any.whl", hash = "sha256:4331535f7aabb505c732fa4c3c094313fc0a1d5ea19907bf4726a7819a68b93f"},
-    {file = "dacite-1.6.0.tar.gz", hash = "sha256:d48125ed0a0352d3de9f493bf980038088f45f3f9d7498f090b50a847daaa6df"},
-]
-grpcio = [
-    {file = "grpcio-1.48.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:4a049a032144641ed5d073535c0dc69eb6029187cc729a66946c86dcc8eec3a1"},
-    {file = "grpcio-1.48.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:f8bc76f5cd95f5476e5285fe5d3704a9332586a569fbbccef551b0b6f7a270f9"},
-    {file = "grpcio-1.48.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:448d397fe88e9fef8170f019b86abdc4d554ae311aaf4dbff1532fde227d3308"},
-    {file = "grpcio-1.48.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f9b6b6f7c83869d2316c5d13f953381881a16741275a34ec5ed5762f11b206e"},
-    {file = "grpcio-1.48.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bd8541c4b6b43c9024496d30b4a12346325d3a17a1f3c80ad8924caed1e35c3"},
-    {file = "grpcio-1.48.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:877d33aeba05ae0b9e81761a694914ed33613f655c35f6bbcf4ebbcb984e0167"},
-    {file = "grpcio-1.48.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cd01a8201fd8ab2ce496f7e65975da1f1e629eac8eea84ead0fd77e32e4350cd"},
-    {file = "grpcio-1.48.0-cp310-cp310-win32.whl", hash = "sha256:0388da923dff58ba7f711233e41c2b749b5817b8e0f137a107672d9c15a1009c"},
-    {file = "grpcio-1.48.0-cp310-cp310-win_amd64.whl", hash = "sha256:8dcffdb8921fd88857ae350fd579277a5f9315351e89ed9094ef28927a46d40d"},
-    {file = "grpcio-1.48.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:2138c50331232f56178c2b36dcfa6ad67aad705fe410955f3b2a53d722191b89"},
-    {file = "grpcio-1.48.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:af2d80f142da2a6af45204a5ca2374e2747af07a99de54a1164111e169a761ff"},
-    {file = "grpcio-1.48.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:59284bd4cdf47c147c26d91aca693765318d524328f6ece2a1a0b85a12a362af"},
-    {file = "grpcio-1.48.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc3ebfe356c0c6750379cd194bf2b7e5d1d2f29db1832358f05a73e9290db98c"},
-    {file = "grpcio-1.48.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc2619a31339e1c53731f54761f1a2cb865d3421f690e00ef3e92f90d2a0c5ae"},
-    {file = "grpcio-1.48.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:7df637405de328a54c1c8c08a3206f974c7a577730f90644af4c3400b7bfde2d"},
-    {file = "grpcio-1.48.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:9e73b95969a579798bfbeb85d376695cce5172357fb52e450467ceb8e7365152"},
-    {file = "grpcio-1.48.0-cp36-cp36m-win32.whl", hash = "sha256:059e9d58b5aba7fb9eabe3a4d2ac49e1dcbc2b54b0f166f6475e40b7f4435343"},
-    {file = "grpcio-1.48.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7cebcf645170f0c82ef71769544f9ac4515993a4d367f5900aba2eb4ecd2a32f"},
-    {file = "grpcio-1.48.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:8af3a8845df35b838104d6fb1ae7f4969d248cf037fa2794916d31e917346f72"},
-    {file = "grpcio-1.48.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:a1ef40975ec9ced6c17ce7fbec9825823da782fa606f0b92392646ff3886f198"},
-    {file = "grpcio-1.48.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:7cccbf6db31f2a78e1909047ff69620f94a4e6e53251858e9502fbbff5714b48"},
-    {file = "grpcio-1.48.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f3f142579f58def64c0850f0bb0eb1b425ae885f5669dda5b73ade64ad2b753"},
-    {file = "grpcio-1.48.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:656c6f6f7b815bca3054780b8cdfa1e4e37cd36c887a48558d00c2cf85f31697"},
-    {file = "grpcio-1.48.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:cba4538e8a2ef123ea570e7b1d62162e158963c2471e35d79eb9690c971a10c0"},
-    {file = "grpcio-1.48.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9daa67820fafceec6194ed1686c1783816e62d6756ff301ba93e682948836846"},
-    {file = "grpcio-1.48.0-cp37-cp37m-win32.whl", hash = "sha256:7ec264a7fb413e0c804a7a48a6f7d7212742955a60724c44d793da35a8f30873"},
-    {file = "grpcio-1.48.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a2b1b33b92359388b8164807313dcbb3317101b038a5d54342982560329d958f"},
-    {file = "grpcio-1.48.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:7b820696a5ce7b98f459f234698cb323f89b355373789188efa126d7f47a2a92"},
-    {file = "grpcio-1.48.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:e4dfae66ebc165c46c5b7048eb554472ee72fbaab2c2c2da7f9b1621c81e077c"},
-    {file = "grpcio-1.48.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:f7115038edce33b494e0138b0bd31a2eb6595d45e2eed23be46bc32886feb741"},
-    {file = "grpcio-1.48.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4e996282238943ca114628255be61980e38b25f73a08ae2ffd02b63eaf70d3a"},
-    {file = "grpcio-1.48.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13dad31f5155fa555d393511cc8108c41b1b5b54dc4c24c27d4694ddd7a78fad"},
-    {file = "grpcio-1.48.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:c84b9d90b2641963de98b35bb7a2a51f78119fe5bd00ef27246ba9f4f0835e36"},
-    {file = "grpcio-1.48.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:41b65166779d7dafac4c98380ac19f690f1c5fe18083a71d370df87b24dd30ff"},
-    {file = "grpcio-1.48.0-cp38-cp38-win32.whl", hash = "sha256:b890e5f5fbc21cb994894f73ecb2faaa66697d8debcb228a5adb0622b9bec3b2"},
-    {file = "grpcio-1.48.0-cp38-cp38-win_amd64.whl", hash = "sha256:5fe3af539d2f50891ed93aed3064ffbcc38bf848aa3f7ed1fbedcce139c57302"},
-    {file = "grpcio-1.48.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:a4ed57f4e3d91259551e6765782b22d9e8b8178fec43ebf8e1b2c392c4ced37b"},
-    {file = "grpcio-1.48.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:60843d8184e171886dd7a93d6672e2ef0b08dfd4f88da7421c10b46b6e031ac4"},
-    {file = "grpcio-1.48.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:0ecba22f25ccde2442be7e7dd7fa746905d628f03312b4a0c9961f0d99771f53"},
-    {file = "grpcio-1.48.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34f5917f0c49a04633dc12d483c8aee6f6d9f69133b700214d3703f72a72f501"},
-    {file = "grpcio-1.48.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4c4ad8ad7e2cf3a272cbc96734d56635e6543939022f17e0c4487f7d2a45bf9"},
-    {file = "grpcio-1.48.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:111fb2f5f4a069f331ae23106145fd16dd4e1112ca223858a922068614dac6d2"},
-    {file = "grpcio-1.48.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:beb0573daa49889efcfea0a6e995b4f39d481aa1b94e1257617406ef417b56a6"},
-    {file = "grpcio-1.48.0-cp39-cp39-win32.whl", hash = "sha256:ce70254a082cb767217b2fdee374cc79199d338d46140753438cd6d67c609b2f"},
-    {file = "grpcio-1.48.0-cp39-cp39-win_amd64.whl", hash = "sha256:ae3fd135666448058fe277d93c10e0f18345fbcbb015c4642de2fa3db6f0c205"},
-    {file = "grpcio-1.48.0.tar.gz", hash = "sha256:eaf4bb73819863440727195411ab3b5c304f6663625e66f348e91ebe0a039306"},
-]
-importlib-metadata = [
-    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
-    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
-]
-isort = [
-    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
-    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
-]
-mypy = [
-    {file = "mypy-0.961-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:697540876638ce349b01b6786bc6094ccdaba88af446a9abb967293ce6eaa2b0"},
-    {file = "mypy-0.961-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b117650592e1782819829605a193360a08aa99f1fc23d1d71e1a75a142dc7e15"},
-    {file = "mypy-0.961-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bdd5ca340beffb8c44cb9dc26697628d1b88c6bddf5c2f6eb308c46f269bb6f3"},
-    {file = "mypy-0.961-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3e09f1f983a71d0672bbc97ae33ee3709d10c779beb613febc36805a6e28bb4e"},
-    {file = "mypy-0.961-cp310-cp310-win_amd64.whl", hash = "sha256:e999229b9f3198c0c880d5e269f9f8129c8862451ce53a011326cad38b9ccd24"},
-    {file = "mypy-0.961-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b24be97351084b11582fef18d79004b3e4db572219deee0212078f7cf6352723"},
-    {file = "mypy-0.961-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f4a21d01fc0ba4e31d82f0fff195682e29f9401a8bdb7173891070eb260aeb3b"},
-    {file = "mypy-0.961-cp36-cp36m-win_amd64.whl", hash = "sha256:439c726a3b3da7ca84a0199a8ab444cd8896d95012c4a6c4a0d808e3147abf5d"},
-    {file = "mypy-0.961-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5a0b53747f713f490affdceef835d8f0cb7285187a6a44c33821b6d1f46ed813"},
-    {file = "mypy-0.961-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0e9f70df36405c25cc530a86eeda1e0867863d9471fe76d1273c783df3d35c2e"},
-    {file = "mypy-0.961-cp37-cp37m-win_amd64.whl", hash = "sha256:b88f784e9e35dcaa075519096dc947a388319cb86811b6af621e3523980f1c8a"},
-    {file = "mypy-0.961-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d5aaf1edaa7692490f72bdb9fbd941fbf2e201713523bdb3f4038be0af8846c6"},
-    {file = "mypy-0.961-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6"},
-    {file = "mypy-0.961-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f4b794db44168a4fc886e3450201365c9526a522c46ba089b55e1f11c163750d"},
-    {file = "mypy-0.961-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:64759a273d590040a592e0f4186539858c948302c653c2eac840c7a3cd29e51b"},
-    {file = "mypy-0.961-cp38-cp38-win_amd64.whl", hash = "sha256:63e85a03770ebf403291ec50097954cc5caf2a9205c888ce3a61bd3f82e17569"},
-    {file = "mypy-0.961-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f1332964963d4832a94bebc10f13d3279be3ce8f6c64da563d6ee6e2eeda932"},
-    {file = "mypy-0.961-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:006be38474216b833eca29ff6b73e143386f352e10e9c2fbe76aa8549e5554f5"},
-    {file = "mypy-0.961-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9940e6916ed9371809b35b2154baf1f684acba935cd09928952310fbddaba648"},
-    {file = "mypy-0.961-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a5ea0875a049de1b63b972456542f04643daf320d27dc592d7c3d9cd5d9bf950"},
-    {file = "mypy-0.961-cp39-cp39-win_amd64.whl", hash = "sha256:1ece702f29270ec6af25db8cf6185c04c02311c6bb21a69f423d40e527b75c56"},
-    {file = "mypy-0.961-py3-none-any.whl", hash = "sha256:03c6cc893e7563e7b2949b969e63f02c000b32502a1b4d1314cabe391aa87d66"},
-    {file = "mypy-0.961.tar.gz", hash = "sha256:f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492"},
-]
-mypy-extensions = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
-]
-pathspec = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
-]
-platformdirs = [
-    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
-    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
-]
-protobuf = [
-    {file = "protobuf-3.20.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3cc797c9d15d7689ed507b165cd05913acb992d78b379f6014e013f9ecb20996"},
-    {file = "protobuf-3.20.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:ff8d8fa42675249bb456f5db06c00de6c2f4c27a065955917b28c4f15978b9c3"},
-    {file = "protobuf-3.20.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cd68be2559e2a3b84f517fb029ee611546f7812b1fdd0aa2ecc9bc6ec0e4fdde"},
-    {file = "protobuf-3.20.1-cp310-cp310-win32.whl", hash = "sha256:9016d01c91e8e625141d24ec1b20fed584703e527d28512aa8c8707f105a683c"},
-    {file = "protobuf-3.20.1-cp310-cp310-win_amd64.whl", hash = "sha256:32ca378605b41fd180dfe4e14d3226386d8d1b002ab31c969c366549e66a2bb7"},
-    {file = "protobuf-3.20.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9be73ad47579abc26c12024239d3540e6b765182a91dbc88e23658ab71767153"},
-    {file = "protobuf-3.20.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:097c5d8a9808302fb0da7e20edf0b8d4703274d140fd25c5edabddcde43e081f"},
-    {file = "protobuf-3.20.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e250a42f15bf9d5b09fe1b293bdba2801cd520a9f5ea2d7fb7536d4441811d20"},
-    {file = "protobuf-3.20.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cdee09140e1cd184ba9324ec1df410e7147242b94b5f8b0c64fc89e38a8ba531"},
-    {file = "protobuf-3.20.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:af0ebadc74e281a517141daad9d0f2c5d93ab78e9d455113719a45a49da9db4e"},
-    {file = "protobuf-3.20.1-cp37-cp37m-win32.whl", hash = "sha256:755f3aee41354ae395e104d62119cb223339a8f3276a0cd009ffabfcdd46bb0c"},
-    {file = "protobuf-3.20.1-cp37-cp37m-win_amd64.whl", hash = "sha256:62f1b5c4cd6c5402b4e2d63804ba49a327e0c386c99b1675c8a0fefda23b2067"},
-    {file = "protobuf-3.20.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:06059eb6953ff01e56a25cd02cca1a9649a75a7e65397b5b9b4e929ed71d10cf"},
-    {file = "protobuf-3.20.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:cb29edb9eab15742d791e1025dd7b6a8f6fcb53802ad2f6e3adcb102051063ab"},
-    {file = "protobuf-3.20.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:69ccfdf3657ba59569c64295b7d51325f91af586f8d5793b734260dfe2e94e2c"},
-    {file = "protobuf-3.20.1-cp38-cp38-win32.whl", hash = "sha256:dd5789b2948ca702c17027c84c2accb552fc30f4622a98ab5c51fcfe8c50d3e7"},
-    {file = "protobuf-3.20.1-cp38-cp38-win_amd64.whl", hash = "sha256:77053d28427a29987ca9caf7b72ccafee011257561259faba8dd308fda9a8739"},
-    {file = "protobuf-3.20.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6f50601512a3d23625d8a85b1638d914a0970f17920ff39cec63aaef80a93fb7"},
-    {file = "protobuf-3.20.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:284f86a6207c897542d7e956eb243a36bb8f9564c1742b253462386e96c6b78f"},
-    {file = "protobuf-3.20.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7403941f6d0992d40161aa8bb23e12575637008a5a02283a930addc0508982f9"},
-    {file = "protobuf-3.20.1-cp39-cp39-win32.whl", hash = "sha256:db977c4ca738dd9ce508557d4fce0f5aebd105e158c725beec86feb1f6bc20d8"},
-    {file = "protobuf-3.20.1-cp39-cp39-win_amd64.whl", hash = "sha256:7e371f10abe57cee5021797126c93479f59fccc9693dafd6bd5633ab67808a91"},
-    {file = "protobuf-3.20.1-py2.py3-none-any.whl", hash = "sha256:adfc6cf69c7f8c50fd24c793964eef18f0ac321315439d94945820612849c388"},
-    {file = "protobuf-3.20.1.tar.gz", hash = "sha256:adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9"},
-]
-six = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
-temporalio = [
-    {file = "temporalio-0.1a2-cp37-abi3-macosx_10_16_x86_64.whl", hash = "sha256:f8f3c7fbe68a57161275e77170de28caff1236960c0f2f2fe43cede87cb52c7f"},
-    {file = "temporalio-0.1a2-cp37-abi3-macosx_12_0_arm64.whl", hash = "sha256:6453e1e258002bbc72147d4f1abbc366274d77b9cc6d03af6adad53e64727412"},
-    {file = "temporalio-0.1a2-cp37-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:d4f4c8d2867e05a68ea1c0e9ce31e9d5ba6ad62405d54a76aa12528b569c32d6"},
-    {file = "temporalio-0.1a2-cp37-abi3-win_amd64.whl", hash = "sha256:ea318a9a5d08675e32fe7a42abc668d7dc5f9982db9abcc386a68d5e13b57929"},
-    {file = "temporalio-0.1a2.tar.gz", hash = "sha256:bf55a94b6eb97bb6433f09752debd1b41dc5fc91b73b69e10417b1bb1f069a3d"},
-]
-tomli = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-typed-ast = [
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
-    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
-    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
-    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
-    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
-types-protobuf = [
-    {file = "types-protobuf-3.19.22.tar.gz", hash = "sha256:d2b26861b0cb46a3c8669b0df507b7ef72e487da66d61f9f3576aa76ce028a83"},
-    {file = "types_protobuf-3.19.22-py3-none-any.whl", hash = "sha256:d291388678af91bb045fafa864f142dc4ac22f5d4cdca097c7d8d8a32fa9b3ab"},
-]
-typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
-]
-zipp = [
-    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
-    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
-]
+black = []
+click = []
+colorama = []
+dacite = []
+grpcio = []
+importlib-metadata = []
+isort = []
+mypy = []
+mypy-extensions = []
+pathspec = []
+platformdirs = []
+protobuf = []
+six = []
+temporalio = []
+tomli = []
+typed-ast = []
+types-protobuf = []
+typing-extensions = []
+zipp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-temporalio = "^0.1a2"
+temporalio = "^0.1b1"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.961"


### PR DESCRIPTION
## What was changed

New `prepare` command that lets you prepare a directory before run.

## Why?

Some builds take a long time, this allows one to prebuild once and run against it multiple times.

## Checklist

1. Closes #104 