### PR TITLE
Use arduino/setup-protoc for TS

### DIFF
--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.17'

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -40,6 +40,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
+      - name: Install protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.17'


### PR DESCRIPTION
As of 1.4, TS no longer includes `@protobuf-ts/protoc` due to this issue in CI:

ETXTBSY linux: https://github.com/temporalio/sdk-typescript/actions/runs/3147258062/jobs/5116588838
EBUSY windows: https://github.com/temporalio/sdk-typescript/actions/runs/3147014208/jobs/5116596522
