### PR TITLE
Test eager activity + non-remote-activities worker

### DIFF
--- a/features/eager_activity/non_remote_activities_worker/README.md
+++ b/features/eager_activity/non_remote_activities_worker/README.md
@@ -1,0 +1,9 @@
+# Eager activities with non-remote-activities worker
+
+When an eager activity is scheduled by a workflow on a non-remote-activities worker, verify it does not get executed and the worker does not crash.
+
+# Detailed spec
+
+- Start a worker with activities registered and non-local activities disabled
+- Run a workflow that schedules a single activity with short schedule-to-close timeout
+- Catch activity failure in the workflow, check that it is caused by schedule-to-start timeout

--- a/features/eager_activity/non_remote_activities_worker/feature.go
+++ b/features/eager_activity/non_remote_activities_worker/feature.go
@@ -1,0 +1,46 @@
+package non_remote_activities_worker
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk-features/harness/go/harness"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+// Start a worker with activities registered and non-local activities disabled
+var Feature = harness.Feature{
+	WorkerOptions: worker.Options{LocalActivityWorkerOnly: true},
+	Workflows:     Workflow,
+	Activities:    Dummy,
+}
+
+func Workflow(ctx workflow.Context) error {
+	// Run a workflow that schedules a single activity with short schedule-to-close timeout
+	// Pick a long enough timeout for busy CI but not too long to get feedback quickly
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 3 * time.Second,
+	})
+
+	err := workflow.ExecuteActivity(ctx, Dummy).Get(ctx, nil)
+	// Catch activity failure in the workflow, check that it is caused by schedule-to-start timeout
+	if err == nil {
+		return fmt.Errorf("expected activity to time out")
+	}
+	if !temporal.IsTimeoutError(err) {
+		return fmt.Errorf("expected a TimeoutError, got: %s", err)
+	}
+	timeoutType := err.(*temporal.ActivityError).Unwrap().(*temporal.TimeoutError).TimeoutType()
+	if timeoutType != enums.TIMEOUT_TYPE_SCHEDULE_TO_START {
+		return fmt.Errorf("expected SCHEDULE_TO_START timeout, got: %s", timeoutType.String())
+	}
+	return nil
+}
+
+func Dummy(ctx context.Context) error {
+	return nil
+}

--- a/features/eager_activity/non_remote_activities_worker/feature.java
+++ b/features/eager_activity/non_remote_activities_worker/feature.java
@@ -1,0 +1,55 @@
+package eager_activity.non_remote_activities_worker;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.api.enums.v1.TimeoutType;
+import io.temporal.failure.ActivityFailure;
+import io.temporal.failure.TimeoutFailure;
+import io.temporal.sdkfeatures.Feature;
+import io.temporal.sdkfeatures.SimpleWorkflow;
+import io.temporal.worker.WorkerOptions;
+
+import java.time.Duration;
+
+@ActivityInterface
+public interface feature extends Feature, SimpleWorkflow {
+  // Start a worker with activities registered and non-local activities disabled
+  @Override
+  default void workerOptions(WorkerOptions.Builder builder) {
+    builder.setLocalActivityWorkerOnly(true);
+  }
+
+  @ActivityMethod
+  void dummy();
+
+  class Impl implements feature {
+    @Override
+    public void workflow() {
+      // Run a workflow that schedules a single activity with short schedule-to-close
+      // timeout
+      var activities = activities(feature.class, builder -> builder
+          // Pick a long enough timeout for busy CI but not too long to get feedback
+          // quickly
+          .setScheduleToCloseTimeout(Duration.ofSeconds(3)));
+
+      try {
+        activities.dummy();
+        throw new RuntimeException("Expected activity to throw");
+      } catch (ActivityFailure e) {
+        // Catch activity failure in the workflow, check that it is caused by
+        // schedule-to-start timeout
+        if (e.getCause() instanceof TimeoutFailure) {
+          var timeoutFailure = ((TimeoutFailure) e.getCause());
+          if (timeoutFailure.getTimeoutType() == TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE) {
+            return;
+          }
+        }
+        throw e;
+      }
+    }
+
+    @Override
+    public void dummy() {
+    }
+  }
+}

--- a/features/eager_activity/non_remote_activities_worker/feature.py
+++ b/features/eager_activity/non_remote_activities_worker/feature.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+
+from temporalio import activity, workflow
+from temporalio.exceptions import ActivityError, TimeoutError, TimeoutType
+from temporalio.worker import WorkerConfig
+
+from harness.python.feature import register_feature
+
+
+@workflow.defn
+class Workflow:
+    @workflow.run
+    async def run(self) -> None:
+        # Run a workflow that schedules a single activity with short schedule-to-close timeout
+        try:
+            await workflow.execute_activity(
+                dummy,
+                # Pick a long enough timeout for busy CI but not too long to get feedback quickly
+                schedule_to_close_timeout=timedelta(seconds=3),
+            )
+            raise RuntimeError("Expected activity to time out")
+        except ActivityError as e:
+            # Catch activity failure in the workflow, check that it is caused by schedule-to-start timeout
+            if not isinstance(e.cause, TimeoutError):
+                raise e
+
+            assert isinstance(e.cause, TimeoutError)
+            if e.cause.type != TimeoutType.SCHEDULE_TO_START:
+                raise e
+
+
+@activity.defn
+async def dummy() -> None:
+    pass
+
+
+# Start a worker with activities registered and non-local activities disabled
+register_feature(
+    workflows=[Workflow],
+    activities=[dummy],
+    worker_config=WorkerConfig(no_remote_activities=True),
+)

--- a/features/eager_activity/non_remote_activities_worker/feature.ts
+++ b/features/eager_activity/non_remote_activities_worker/feature.ts
@@ -1,0 +1,40 @@
+import * as wf from '@temporalio/workflow';
+import { TimeoutType } from '@temporalio/common';
+import { Feature } from '@temporalio/harness';
+
+const activities = wf.proxyActivities<typeof activitiesImpl>({
+  // Pick a long enough timeout for busy CI but not too long to get feedback quickly
+  scheduleToCloseTimeout: '3 seconds',
+});
+
+export async function workflow(): Promise<void> {
+  // Run a workflow that schedules a single activity with short schedule-to-close timeout
+  try {
+    await activities.dummy();
+    throw new Error('Expected activity to time out');
+  } catch (err) {
+    // Catch activity failure in the workflow, check that it is caused by schedule-to-start timeout
+    if (
+      !(
+        err instanceof wf.ActivityFailure &&
+        err.cause instanceof wf.TimeoutFailure &&
+        err.cause.timeoutType === TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_START
+      )
+    ) {
+      throw err;
+    }
+  }
+}
+
+const activitiesImpl = {
+  async dummy() {
+    // noop
+  },
+};
+
+// Start a worker with activities registered and non-local activities disabled
+export const feature = new Feature({
+  workerOptions: { enableNonLocalActivities: false },
+  activities: activitiesImpl,
+  workflow,
+});

--- a/features/features.go
+++ b/features/features.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk-features/features/continue_as_new/continue_as_same"
 	"go.temporal.io/sdk-features/features/data_converter/binary"
 	"go.temporal.io/sdk-features/features/data_converter/empty"
+	"go.temporal.io/sdk-features/features/eager_activity/non_remote_activities_worker"
 	"go.temporal.io/sdk-features/features/query/successful_query"
 	"go.temporal.io/sdk-features/features/query/timeout_due_to_no_active_workers"
 	"go.temporal.io/sdk-features/features/query/unexpected_arguments"
@@ -48,5 +49,6 @@ func init() {
 		unexpected_arguments.Feature,
 		unexpected_query_type_name.Feature,
 		unexpected_return_type.Feature,
+		non_remote_activities_worker.Feature,
 	)
 }

--- a/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
+++ b/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
@@ -11,14 +11,14 @@ public class PreparedFeature {
       continue_as_new.continue_as_same.feature.Impl.class,
       data_converter.binary.feature.Impl.class,
       data_converter.empty.feature.Impl.class,
+      eager_activity.non_remote_activities_worker.feature.Impl.class,
       query.successful_query.feature.Impl.class,
       query.timeout_due_to_no_active_workers.feature.Impl.class,
       query.unexpected_arguments.feature.Impl.class,
       query.unexpected_query_type_name.feature.Impl.class,
       query.unexpected_return_type.feature.Impl.class,
       schedule.cron.feature.Impl.class,
-      signal.external.feature.Impl.class
-  );
+      signal.external.feature.Impl.class);
 
   @SafeVarargs
   static PreparedFeature[] prepareFeatures(Class<? extends Feature>... classes) {

--- a/harness/python/feature.py
+++ b/harness/python/feature.py
@@ -13,7 +13,7 @@ from temporalio import workflow
 from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.service import TLSConfig
-from temporalio.worker import Worker
+from temporalio.worker import Worker, WorkerConfig
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,7 @@ def register_feature(
     start: Optional[Callable[[Runner], Awaitable[WorkflowHandle]]] = None,
     start_options: Mapping[str, Any] = {},
     check_result: Optional[Callable[[Runner, WorkflowHandle], Awaitable[None]]] = None,
+    worker_config: WorkerConfig = WorkerConfig(),
 ) -> None:
     # No need to register in a sandbox
     if workflow.unsafe.in_sandbox():
@@ -52,6 +53,7 @@ def register_feature(
         start=start,
         start_options=start_options,
         check_result=check_result,
+        worker_config=worker_config,
     )
 
 
@@ -66,6 +68,7 @@ class Feature:
     start: Optional[Callable[[Runner], Awaitable[WorkflowHandle]]]
     start_options: Mapping[str, Any]
     check_result: Optional[Callable[[Runner, WorkflowHandle], Awaitable[None]]]
+    worker_config: Optional[WorkerConfig]
 
 
 class Runner:
@@ -158,6 +161,7 @@ class Runner:
             task_queue=self.task_queue,
             workflows=self.feature.workflows,
             activities=self.feature.activities,
+            **self.feature.worker_config,
         )
         self._worker_task = asyncio.create_task(self.worker.run())
 

--- a/harness/ts/harness.ts
+++ b/harness/ts/harness.ts
@@ -41,6 +41,11 @@ export interface FeatureOptions<W extends Workflow, A extends UntypedActivities>
   workflowStartOptions?: Partial<WorkflowStartOptions<W>>;
 
   /**
+   * Optional worker options to augment worker creation for the feature.
+   */
+  workerOptions?: Partial<WorkerOptions>;
+
+  /**
    * Execute the workflow. If unset, defaults to
    * Runner.executeSingleParameterlessWorkflow.
    */
@@ -152,6 +157,7 @@ export class Runner<W extends Workflow, A extends UntypedActivities> {
         activityInbound: [() => new ConnectionInjectorInterceptor(connection, client)],
         workflowModules: [require.resolve('./workflow-globals-injection-interceptors')],
       }),
+      ...feature.options.workerOptions,
     };
     const worker = await Worker.create(workerOpts);
     const workerRunPromise = (async () => {


### PR DESCRIPTION
Verifying that the worker doesn't crash with this combination as observed and fixed in Core based SDKs.