### PR TITLE
Fix obnoxious caching problem w/ namespaces

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -80,6 +80,8 @@ jobs:
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests
         if: inputs.docker-image-artifact-name
+        env:
+          WAIT_EXTRA_FOR_NAMESPACE: true
         run: |
           docker-compose \
             -f /tmp/server-docker/docker-compose.yml \

--- a/harness/go/harness/util.go
+++ b/harness/go/harness/util.go
@@ -5,9 +5,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"go.temporal.io/sdk/log"
+	"os"
 	"strings"
 	"time"
+
+	"go.temporal.io/sdk/log"
 
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/sdk/client"
@@ -72,6 +74,12 @@ func WaitNamespaceAvailable(ctx context.Context, logger log.Logger,
 	})
 	if lastErr != nil {
 		return fmt.Errorf("failed connecting after 5s, last error: %w", lastErr)
+	}
+	// Because of annoying caching nonsense, sometimes the namespace might look available here but
+	// not for other operations. That should resolve quickly. Ideally we can remove this whole
+	// function when https://github.com/temporalio/temporal/issues/1336 is fixed
+	if _, ok := os.LookupEnv("WAIT_EXTRA_FOR_NAMESPACE"); ok {
+		time.Sleep(3 * time.Second)
 	}
 	return nil
 }


### PR DESCRIPTION
This appears to be sadly necessary when using the sdk-features docker image