### PR TITLE
Add GH token to protoc action

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -73,7 +73,9 @@ jobs:
       - name: Install Protoc
         if: ${{ inputs.version-is-repo-ref }}
         uses: arduino/setup-protoc@v1
-
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v1
         if: ${{ inputs.version-is-repo-ref }}
         with:


### PR DESCRIPTION
## What was changed

Added GH secret to protoc download action for Python CI the same way it is done for TS

## Why?

Was being rate limited, see https://github.com/arduino/setup-protoc#usage